### PR TITLE
Search php binary in user's $PATH is more flexibel

### DIFF
--- a/bin/phpcf
+++ b/bin/phpcf
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 // ? create-project installation : require installation
 $vendor_dir = is_dir(dirname(dirname((__FILE__))).'/vendor') ? dirname(dirname((__FILE__))).'/vendor' : dirname(dirname(dirname(dirname(__FILE__))));


### PR DESCRIPTION
When I try to run `phpcf` I get the following error:

```
$ phpcf
bash: phpcf: /usr/bin/php: bad interpreter: No such file or directory
```

Not everyone has the php binary in `/usr/bin`. For example my binary is located in `/usr/local/bin`. I replaced the interpreter `#!/usr/bin/php` in `phpcf` with `#!/usr/bin/env php` to search dynamically for the php binary in user's $PATH.