### PR TITLE
Added parameter skip-checks & allow PCRE bracket style delimiters

### DIFF
--- a/bin/phpcf
+++ b/bin/phpcf
@@ -28,15 +28,16 @@ $doc = <<<DOC
 PhpCodeFixer $version
 
 Usage:
-    phpcf [--target VERSION] [--max-size SIZE] [--exclude NAME] [--file-extensions EXT] FILES...
+    phpcf [--target VERSION] [--max-size SIZE] [--exclude NAME] [--file-extensions EXT] [--skip-checks CHECKS] FILES...
     phpcf --version
 
 Options:
   -v --version             Show version.
-  -t --target VERSION      Sets target php version. [default: 7.2]
-  -e --exclude NAME        Sets excluded file or directory names for scanning. If need to pass few names, join it with comma.
-  -s --max-size SIZE       Sets max size of php file. If file is larger, it will be skipped. [default: 1mb]
-     --file-extensions EXT Sets file extensions to be parsed. [default: php, phtml, php5]
+  -t --target VERSION      Change the target php version. [default: 7.2]
+  -e --exclude NAME        Exclude files / directories for scanning. Pass a comma-separated list for multiple values.
+  -s --max-size SIZE       Skip files exceeding the max. size. [default: 1mb]
+     --file-extensions EXT Only parse files with the given extension(s). Pass a comma-separated list for multiple values. [default: php, phtml, php5]
+     --skip-checks CHECKS  Skip all checks containing any of the given values. Pass a comma-separated list for multiple values.
 
 DOC;
 

--- a/data/preg_replace_e_modifier.php
+++ b/data/preg_replace_e_modifier.php
@@ -12,26 +12,23 @@ function preg_replace_e_modifier(array $usage_tokens) {
     $data = PhpCodeFixer::trimSpaces($data[0]);
 
     // getting delimiter
-    if ($data[0][0] == T_CONSTANT_ENCAPSED_STRING) {
-        $string = trim($data[0][1], '\'"');
-        $delimiter = $string{0};
-        if ($data[count($data)-1][0] == T_CONSTANT_ENCAPSED_STRING) {
-            $string = trim($data[count($data)-1][1], '\'"');
-            if (($modificator = strrchr($string, $delimiter)) !== false) {
-                if (strpos($modificator, 'e') !== false) {
-                    return 'Usage of "e" modifier in preg_replace is deprecated: "'.$string.'"';
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
-    } else {
+    if ($data[0][0] != T_CONSTANT_ENCAPSED_STRING) {
         return false;
     }
 
-    return false;
+    $string = trim($data[0][1], '\'"');
+    $delimiter = strtr($string{0}, '({[<', ')}]>');
+
+    if ($data[count($data)-1][0] != T_CONSTANT_ENCAPSED_STRING) {
+        return false;
+    }
+
+    $string = trim($data[count($data)-1][1], '\'"');
+    $modifiers = strrchr($string, $delimiter);
+
+    if (empty($modifiers) || strpos($modifiers, 'e') === false) {
+        return false;
+    }
+
+    return 'Usage of "e" modifier in preg_replace is deprecated: "'.$string.'"';
 }


### PR DESCRIPTION
Our codebase is quite big, so we've decided to create mysql* wrapper functions instead of replacing them one by one. Therefor I've needed a parameter to skip these checks.

Also with PCRE you may use bracket style delimiters, so I've extended your modifier check to translate the delimiter.

Oh and I've changed the explanations in the usage text, I hope you don't mind.