### PR TITLE
PHP4 constructors, preg_replace, method naming for subclasses

### DIFF
--- a/data/php4_constructors.php
+++ b/data/php4_constructors.php
@@ -6,10 +6,13 @@ namespace wapmorgan\PhpCodeFixer;
  * @param $className
  * @param $methodName
  * @param array $methodAttributes
+ * @param array $methods -- all methods of the given class
  * @return bool
  */
-function php4_constructors($className, $methodName, array $methodAttributes) {
-    if (strcasecmp($className, $methodName) === 0 && !in_array('static', $methodAttributes, true))
+function php4_constructors($className, $methodName, array $methodAttributes, array $methods) {
+    if (strcasecmp($className, $methodName) === 0 && !in_array('static', $methodAttributes, true) && !array_key_exists('__construct', $methods)) {
         return 'You should use __constructor() method instead of "'.$methodName.'"';
+    }
+
     return false;
 }

--- a/data/php4_constructors.php
+++ b/data/php4_constructors.php
@@ -7,10 +7,11 @@ namespace wapmorgan\PhpCodeFixer;
  * @param $methodName
  * @param array $methodAttributes
  * @param array $methods -- all methods of the given class
+ * @param string $namespace -- default: null
  * @return bool
  */
-function php4_constructors($className, $methodName, array $methodAttributes, array $methods) {
-    if (strcasecmp($className, $methodName) === 0 && !in_array('static', $methodAttributes, true) && !array_key_exists('__construct', $methods)) {
+function php4_constructors($className, $methodName, array $methodAttributes, array $methods, $namespace = '') {
+    if (strcasecmp($className, $methodName) === 0 && !in_array('static', $methodAttributes, true) && !array_key_exists('__construct', $methods) && empty($namespace)) {
         return 'You should use __constructor() method instead of "'.$methodName.'"';
     }
 

--- a/data/preg_replace_e_modifier.php
+++ b/data/preg_replace_e_modifier.php
@@ -16,7 +16,7 @@ function preg_replace_e_modifier(array $usage_tokens) {
         return false;
     }
 
-    $string = trim($data[0][1], '\'"');
+    $string = substr($data[0][1], 1, -1);
     $delimiter = strtr($string{0}, '({[<', ')}]>');
 
     if ($data[count($data)-1][0] != T_CONSTANT_ENCAPSED_STRING) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -155,7 +155,10 @@ class Application
                 $this->reports[] = PhpCodeFixer::checkDir(rtrim(realpath($file), DIRECTORY_SEPARATOR), $this->issuesBank, $this->excludeList, $this->skipChecks);
             } else if (is_file($file)) {
                 $report = new Report('File '.basename($file), dirname(realpath($file)));
-                $this->reports[] = PhpCodeFixer::checkFile(realpath($file), $this->issuesBank, $this->skipChecks, $report);
+                $report = PhpCodeFixer::checkFile(realpath($file), $this->issuesBank, $this->skipChecks, $report);
+                if($report instanceof Report) {
+                    $this->reports[] = $report;
+                }
             }
         }
     }

--- a/src/PhpCodeFixer.php
+++ b/src/PhpCodeFixer.php
@@ -182,12 +182,31 @@ class PhpCodeFixer {
             }
         }
 
+        $function_declaration = false;
+
         foreach ($tokens as $i => $token) {
-            if ($token[0] != T_STRING
-                || (isset($tokens[$i - 2]) && is_array($tokens[$i - 2]) && in_array($tokens[$i - 2][0], [T_FUNCTION], true))
-                || !isset($tokens[$i + 1])
-                || $tokens[$i + 1] !== '(')
+            if ($token[0] == T_FUNCTION) {
+                $function_declaration = true;
                 continue;
+            }
+
+            if ($function_declaration === true) {
+                if ($token === '{') {
+                    $function_declaration = false;
+                }
+
+                continue;
+            }
+
+            // not a string: for sure not a function / method call
+            if ($token[0] != T_STRING) {
+                continue;
+            }
+
+            // check if the next non-whitespace character is '('
+            if ((!isset($tokens[$i + 1]) || $tokens[$i + 1] !== '(') && (!isset($tokens[$i + 2]) || $tokens[$i + 2] !== '(')) {
+                continue;
+            }
 
             if (!isset($deprecated_functions_usage[$token[1]]) && empty($global_deprecated_usage_checkers))
                 continue;

--- a/src/PhpCodeFixer.php
+++ b/src/PhpCodeFixer.php
@@ -249,7 +249,10 @@ class PhpCodeFixer {
                 if (!is_array($tokens[$class_start-1]) || $tokens[$class_start-1][1] != '::') {
                     $class_name = $tokens[$i+2][1];
                     $braces = 1;
-                    $i += 5;
+                    while($tokens[$i] !== '{') {
+                    	$i++;
+                    }
+                    $i++;
                     while (($braces > 0) && (($i+1) <= $total)) {
                         if ($tokens[$i] == '{') {
                             $braces++;

--- a/src/PhpCodeFixer.php
+++ b/src/PhpCodeFixer.php
@@ -210,7 +210,7 @@ class PhpCodeFixer {
         }
 
         // find for deprecated variables
-        $deprecated_variables = $issues->getAll('variables');
+        $deprecated_variables = self::filterSkippedChecks($issues->getAll('variables'), $skipChecks);
         $used_variables = array_filter_by_column($tokens, T_VARIABLE, 0);
         foreach ($used_variables as $used_variable) {
             if (isset($deprecated_variables[$used_variable[1]])) {
@@ -224,7 +224,7 @@ class PhpCodeFixer {
         if (defined('T_TRAIT')) $oop_words[] = T_TRAIT;
 
         // find for reserved identifiers used as names
-        $identifiers = $issues->getAll('identifiers');
+        $identifiers = self::filterSkippedChecks($issues->getAll('identifiers'), $skipChecks);
         if (!empty($identifiers)) {
             foreach ($tokens as $i => $token) {
                 if (in_array($token[0], $oop_words)) {
@@ -240,7 +240,7 @@ class PhpCodeFixer {
         }
 
         // find for methods naming deprecations
-        $methods_naming = $issues->getAll('methods_naming');
+        $methods_naming = self::filterSkippedChecks($issues->getAll('methods_naming'), $skipChecks);
         if (!empty($methods_naming)) {
             while (in_array_column($tokens, T_CLASS, 0)) {
                 $total = count($tokens);
@@ -248,10 +248,10 @@ class PhpCodeFixer {
                 $class_start = $i;
                 if (!is_array($tokens[$class_start-1]) || $tokens[$class_start-1][1] != '::') {
                     $class_name = $tokens[$i+2][1];
-	                $methods = [];
+                    $methods = [];
                     $braces = 1;
                     while($tokens[$i] !== '{') {
-                    	$i++;
+                        $i++;
                     }
                     $i++;
                     while (($braces > 0) && (($i+1) <= $total)) {

--- a/src/PhpCodeFixer.php
+++ b/src/PhpCodeFixer.php
@@ -270,18 +270,21 @@ class PhpCodeFixer {
                                 $attributes_index += 2;
                             }
                             $method_name = $tokens[$i+2][1];
-                            $methods[$method_name] = $method_attributes;
+                            $methods[$method_name] = [
+                                'line' => $tokens[$i][2],
+                                'attributes' => $method_attributes
+                            ];
                         }
                         $i++;
                     }
-                    foreach ($methods as $method_name => $method_attributes) {
+                    foreach ($methods as $method_name => $method_data) {
                         foreach ($methods_naming as $methods_naming_checker) {
                             $checker = ltrim($methods_naming_checker[0], '@');
                             require_once dirname(dirname(__FILE__)).'/data/'.$checker.'.php';
                             $checker = __NAMESPACE__.'\\'.$checker;
-                            $result = $checker($class_name, $method_name, $method_attributes, $methods);
+                            $result = $checker($class_name, $method_name, $method_data['attributes'], $methods);
                             if($result !== false) {
-                                $report->add($methods_naming_checker[1], 'method_name', $method_name.':'.$class_name.' ('.$methods_naming_checker[0].')', null, $file, $tokens[$i][2]);
+                                $report->add($methods_naming_checker[1], 'method_name', $method_name.':'.$class_name.' ('.$methods_naming_checker[0].')', null, $file, $method_data['line']);
                             }
                         }
                     }


### PR DESCRIPTION
I've fixed issue #28 with the second commit. The first one fixes another preg_replace delimiter issue, it's also allowed to use single-/double-quotes as delimiters. Also the method naming check didn't work for subclasses (eg. class SubClass extends ParentClass) as there were more tokens than just 5 to get after the first opening brace.